### PR TITLE
Update typings to correctly export Matchers interface.

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,10 +1,10 @@
-export declare namespace jest {
+declare namespace jest {
     type expectType = any;
     type returnType = Error | any;
     type yieldValue = [expectType, returnType?];
     type yieldValues = yieldValue[];
 
-	interface Matchers {
+	export interface Matchers<R> {
 		toMatchYields: (yieldValues: yieldValues) => void
 	}
 }


### PR DESCRIPTION
I had issues getting my jest setup to recognise the 'toMatchYields' matcher on the Matcher type. 

Looking at the `typings.d.ts` file it looks like the Matcher interface needs to be exported, not the overall namespace for it to work. 

Here's an example for Express: 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/method-override/index.d.ts

